### PR TITLE
캘린더 컴포넌트에서 event 를 props 로 전달받아 보여주기

### DIFF
--- a/src/components/MyCalendar/CreateEventButton.tsx
+++ b/src/components/MyCalendar/CreateEventButton.tsx
@@ -11,7 +11,7 @@ export interface eventProps {
   end_date?: string;
 }
 
-const CreateEventButton = (props: eventProps) => {
+const CreateEventButton = ({ id, title, start_date, end_date }: eventProps) => {
   const [eventTitle, setTitle] = useState('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
@@ -20,21 +20,19 @@ const CreateEventButton = (props: eventProps) => {
   const endRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    console.log(props);
-
-    if (props.start_date) {
-      setStartDate(props.start_date);
-      startRef!.current!.value = props.start_date;
+    if (start_date) {
+      setStartDate(start_date);
+      startRef!.current!.value = start_date;
     }
-    if (props.end_date) {
-      setEndDate(props.end_date);
-      endRef!.current!.value = props.end_date;
+    if (end_date) {
+      setEndDate(end_date);
+      endRef!.current!.value = end_date;
     }
-    if (props.title) {
-      setTitle(props.title);
-      titleRef!.current!.value = props.title;
+    if (title) {
+      setTitle(title);
+      titleRef!.current!.value = title;
     }
-  }, [props]);
+  }, [start_date, end_date, title]);
 
   const onTitleChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value);
@@ -55,8 +53,8 @@ const CreateEventButton = (props: eventProps) => {
         start: startDate,
         end: endDate === '' ? startDate : endDate,
       };
-      if (props.id) {
-        updatePersonalSchedule(props.id, newEvent).catch((err) => {
+      if (id) {
+        updatePersonalSchedule(id, newEvent).catch((err) => {
           console.log(err);
         });
       } else {
@@ -88,7 +86,7 @@ const CreateEventButton = (props: eventProps) => {
       <InputRef type="date" title="끝 날짜" placeholder="YYYY-MM-DD" onChange={onEndDateChanged} ref={endRef} />
       <hr className="mb-2 mt-2" />
       <button className="btn w-full bg-primary text-base-100" onClick={onCreateClicked}>
-        {props.id ? '수정하기' : '추가하기'}
+        {id ? '수정하기' : '추가하기'}
       </button>
     </div>
   );
@@ -96,8 +94,8 @@ const CreateEventButton = (props: eventProps) => {
     <div className="p-8 pl-0 pr-0">
       <DialogButton
         classname="btn bg-primary text-base-100 w-full"
-        name={props.id ? '수정' : '새 일정 추가하기'}
-        title={props.id ? '일정 수정' : '일정 추가'}
+        name={id ? '수정' : '새 일정 추가하기'}
+        title={id ? '일정 수정' : '일정 추가'}
         desc={''}
         children={eventForm}
       />

--- a/src/components/common/Calendar.tsx
+++ b/src/components/common/Calendar.tsx
@@ -31,6 +31,9 @@ export default function Calendar({ db_events, onDeleteClicked }: CalendarProps) 
   const [selectedEvents, setSelectedEvents] = useState<DB_Events[]>([]);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
 
+  useEffect(() => {
+    console.log('mounted!');
+  }, []);
   /*
   const handleDateClick = (clickInfo: EventClickArg) => {
     if (clickInfo.event.start) {

--- a/src/components/common/Calendar.tsx
+++ b/src/components/common/Calendar.tsx
@@ -31,9 +31,6 @@ export default function Calendar({ db_events, onDeleteClicked }: CalendarProps) 
   const [selectedEvents, setSelectedEvents] = useState<DB_Events[]>([]);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
 
-  useEffect(() => {
-    console.log('mounted!');
-  }, []);
   /*
   const handleDateClick = (clickInfo: EventClickArg) => {
     if (clickInfo.event.start) {

--- a/src/pages/GroupSchedulePage.tsx
+++ b/src/pages/GroupSchedulePage.tsx
@@ -5,6 +5,7 @@ import CreateEventButton from '@/components/MyCalendar/CreateEventButton';
 import { useParams } from 'react-router-dom';
 import { useGetOneGroupSchedule } from '@/react-queries/useGetOneGroupSchedule';
 import { Loading } from '.';
+import { DB_Events } from '@/utils';
 
 const GroupSchedulePage = () => {
   // TODO: 캘린더 수정해서 이벤트 리스트를 외부에서 받을 수 있도록 해야함.
@@ -20,6 +21,16 @@ const GroupSchedulePage = () => {
 
   console.log(data);
 
+  const db_events: DB_Events[] = [];
+  if (data) {
+    db_events.push({ ...data, start_date: data.start_date, end_date: data.end_date, title: data.title, id: data.id });
+  }
+
+  const onDelete = (id: number) => {
+    console.log('delete group id: ', id);
+    // TODO: delete group schedule with id
+  };
+
   return (
     <div className="lg:ml-80">
       {isLoading && <Loading size="lg" display="spinner" color="primary" />}
@@ -27,7 +38,7 @@ const GroupSchedulePage = () => {
       <main className="z-1 relative flex-grow">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="rounded bg-white p-6 px-4 sm:px-0">
-            <Calendar />
+            <Calendar db_events={db_events} onDeleteClicked={onDelete} />
           </div>
         </div>
       </main>

--- a/src/pages/MyCalendarPage.tsx
+++ b/src/pages/MyCalendarPage.tsx
@@ -7,16 +7,15 @@ import { useEventState } from '@/stores/myEventsStore';
 import { useEffect } from 'react';
 
 const MyCalendarPage: React.FC = () => {
-  const { addEvents, db_events, addDBEvents } = useEventState();
+  const { db_events, addDBEvents } = useEventState();
 
   useEffect(() => {
     getPersonalSchedule().then((schedule) => {
       schedule.map((x) => {
         addDBEvents({ ...x });
-        addEvents({ ...x, start: x.start_date, end: x.end_date });
       });
     });
-  }, [addDBEvents, addEvents]);
+  }, [addDBEvents]);
 
   const onDeleteClicked = (id: number) => {
     console.log('delete : ', id);

--- a/src/pages/MyCalendarPage.tsx
+++ b/src/pages/MyCalendarPage.tsx
@@ -7,7 +7,7 @@ import { useEventState } from '@/stores/myEventsStore';
 import { useEffect } from 'react';
 
 const MyCalendarPage: React.FC = () => {
-  const { events, addEvents, db_events, addDBEvents } = useEventState();
+  const { addEvents, db_events, addDBEvents } = useEventState();
 
   useEffect(() => {
     getPersonalSchedule().then((schedule) => {
@@ -16,7 +16,7 @@ const MyCalendarPage: React.FC = () => {
         addEvents({ ...x, start: x.start_date, end: x.end_date });
       });
     });
-  }, [events, addEvents, addDBEvents]);
+  }, [addDBEvents, addEvents]);
 
   const onDeleteClicked = (id: number) => {
     console.log('delete : ', id);

--- a/src/pages/MyCalendarPage.tsx
+++ b/src/pages/MyCalendarPage.tsx
@@ -2,15 +2,40 @@ import AppBar from '@/components/common/AppBar.tsx';
 import Calendar from '../components/common/Calendar.tsx';
 import CreateEventButton from '@/components/MyCalendar/CreateEventButton.tsx';
 import HamburgerButton from '@/components/common/SideBar/HamburgerButton.tsx';
+import { getPersonalSchedule, deletePersonalSchedule } from '@/apis/personalScheduleApi';
+import { useEventState } from '@/stores/myEventsStore';
+import { useEffect } from 'react';
 
 const MyCalendarPage: React.FC = () => {
+  const { events, addEvents, db_events, addDBEvents } = useEventState();
+
+  useEffect(() => {
+    getPersonalSchedule().then((schedule) => {
+      schedule.map((x) => {
+        addDBEvents({ ...x });
+        addEvents({ ...x, start: x.start_date, end: x.end_date });
+      });
+    });
+  }, [events, addEvents, addDBEvents]);
+
+  const onDeleteClicked = (id: number) => {
+    console.log('delete : ', id);
+    deletePersonalSchedule(id)
+      .then((val) => {
+        console.log('delete done!', val);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
   return (
     <div className="lg:ml-80">
       <AppBar backButton={false} IconButton={<HamburgerButton />} calendarName="내 캘린더" />
       <main className="z-1 relative flex-grow">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div>
-            <Calendar />
+            <Calendar db_events={db_events} onDeleteClicked={onDeleteClicked} />
             <CreateEventButton />
           </div>
         </div>

--- a/src/stores/myEventsStore.ts
+++ b/src/stores/myEventsStore.ts
@@ -1,20 +1,12 @@
 import { create } from 'zustand';
-import { Events, DB_Events } from '../utils/index.ts';
+import { DB_Events } from '../utils/index.ts';
 
 interface EventsState {
-  events: Events[];
-  addEvents: (event: Events) => void;
-  initEvents: () => void;
-
   db_events: DB_Events[];
   addDBEvents: (db_event: DB_Events) => void;
 }
 
 export const useEventState = create<EventsState>()((set) => ({
-  events: [],
-  addEvents: (newEvent: Events) => set((state) => ({ events: [...state.events, newEvent] })),
-
   db_events: [],
-  initEvents: () => set(() => ({ events: [] })),
   addDBEvents: (newEvent: DB_Events) => set((state) => ({ db_events: [...state.db_events, newEvent] })),
 }));

--- a/src/stores/myEventsStore.ts
+++ b/src/stores/myEventsStore.ts
@@ -12,20 +12,8 @@ interface EventsState {
 
 export const useEventState = create<EventsState>()((set) => ({
   events: [],
+  addEvents: (newEvent: Events) => set((state) => ({ events: [...state.events, newEvent] })),
 
-  addEvents: (newEvent: Events) =>
-    set((state) => {
-      // 중복 검사 로직 추가
-      const isDuplicate = state.events.some(
-        (event) => event.start === newEvent.start && event.title === newEvent.title,
-      );
-
-      if (!isDuplicate) {
-        return { events: [...state.events, newEvent] };
-      } else {
-        return { events: [...state.events] }; // 중복된 경우 상태 변경 없음
-      }
-    }),
   db_events: [],
   initEvents: () => set(() => ({ events: [] })),
   addDBEvents: (newEvent: DB_Events) => set((state) => ({ db_events: [...state.db_events, newEvent] })),


### PR DESCRIPTION
캘린더 컴포넌트에서 db_events 와 onDeleteClicked 를 전달받아 동작하도록 수정했습니다. 그룹 이벤트도 잘 보이는 것을 확인했습니다.


https://github.com/imaginer-dev/DateLeaf/assets/35310404/e15fb521-add0-4cd4-882e-d85544d7ca48

